### PR TITLE
refactor to make it a stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
+launch.json
+.vscode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,54 @@ pub struct SimpleLinkedList<T> {
     head: Link<T>,
 }
 
+impl<'a, T> Default for SimpleLinkedList<T> {
+    fn default() -> Self {
+        Self { head: None }
+    }
+}
+
+impl<T> From<&[T]> for SimpleLinkedList<T>
+where
+    T: Copy,
+{
+    fn from(array: &[T]) -> Self {
+        let mut new_list: SimpleLinkedList<T> = Default::default();
+        for x in array.iter() {
+            new_list.push(*x);
+        }
+        new_list
+    }
+}
+
+impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
+    fn into(self) -> Vec<T> {
+        let mut return_vec = Vec::new();
+        let mut my_self = self;
+
+        if my_self.head.is_some() {
+            if my_self.head.as_ref().unwrap().next.is_none() {
+                let popped = my_self.head.take().unwrap().data;
+                return_vec.push(popped);
+                return return_vec;
+            }
+
+            let mut curr = my_self.head.take().unwrap();
+            loop {
+                return_vec.push(curr.data);
+                if curr.next.is_none() {
+                    break;
+                }
+                curr = curr.next.take().unwrap();
+            }
+        } 
+
+        return_vec
+    }
+}
+
 impl<'a, T> SimpleLinkedList<T> {
     pub fn new() -> SimpleLinkedList<T> {
-        Self { head: None }
+        Default::default()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -44,24 +89,85 @@ impl<'a, T> SimpleLinkedList<T> {
         count
     }
 
-    pub fn push(&mut self, item : T) {
-        let link = Some(Box::new(Node::new(item)));
-        
-
-        if let Some(mut curr) = self.head.as_ref() {
-            loop {
-                if let Some(next) = &mut curr.next {
-                    *curr = Box::new(**next)
-                } else {
-                    0;
-                    curr.next = Some(Box::new(Node::new(item)));
-                    break;
-                }
-
+    pub fn push(&mut self, item: T) {
+        if self.head.is_some() {
+            // if let Some(curr) = self.head.as_ref() {
+            let mut curr = self.head.as_mut().unwrap();
+            while curr.next.is_some() {
+                curr = curr.next.as_mut().unwrap();
             }
+            curr.next = Some(Box::new(Node::new(item)));
         } else {
             self.head = Some(Box::new(Node::new(item)));
         }
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if self.head.is_some() {
+            if self.head.as_ref().unwrap().next.is_none() {
+                let popped = Some(self.head.take().unwrap().data);
+                self.head = None;
+                return popped;
+            }
+
+            let mut curr = self.head.as_mut().unwrap();
+            while curr.next.is_some() {
+                let curr_next = curr.next.as_ref();
+                if curr_next.unwrap().next.is_none() {
+                    return Some(curr.next.take().unwrap().data);
+                }
+                curr = curr.next.as_mut().unwrap();
+            }
+            None
+        } else {
+            None
+        }
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        if self.head.is_some() {
+            if self.head.as_ref().unwrap().next.is_none() {
+                return Some(&self.head.as_ref().unwrap().data);
+            }
+
+            let mut curr = self.head.as_ref().unwrap();
+            while curr.next.is_some() {
+                let curr_next = curr.next.as_ref();
+                if curr_next.unwrap().next.is_none() {
+                    return Some(&curr.next.as_ref().unwrap().data);
+                }
+                curr = curr.next.as_ref().unwrap();
+            }
+            None
+        } else {
+            None
+        }
+    }
+
+    fn reverser(new_list: &mut SimpleLinkedList<T>, current_node: &mut Link<T>) {
+        let next_node = &mut current_node.as_mut().unwrap().next;
+        if next_node.is_some() {
+            Self::reverser(new_list, next_node);
+        }
+
+        new_list.push(current_node.take().unwrap().data)
+    }
+
+    pub fn rev(&mut self) -> SimpleLinkedList<T> {
+        if self.head.is_none() {
+            return Default::default();
+        }
+
+        if self.head.as_ref().unwrap().next.is_none() {
+            return SimpleLinkedList {
+                head: Some(self.head.take().unwrap()),
+            };
+        }
+
+        let mut new_list: SimpleLinkedList<T> = Default::default();
+        Self::reverser(&mut new_list, &mut self.head);
+
+        new_list
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,21 +42,15 @@ impl<T> Into<Vec<T>> for SimpleLinkedList<T> {
     fn into(self) -> Vec<T> {
         let mut return_vec = Vec::new();
         let mut my_self = self;
-
         if my_self.head.is_some() {
-            if my_self.head.as_ref().unwrap().next.is_none() {
-                let popped = my_self.head.take().unwrap().data;
-                return_vec.push(popped);
-                return return_vec;
-            }
-
-            let mut curr = my_self.head.take().unwrap();
-            loop {
-                return_vec.push(curr.data);
-                if curr.next.is_none() {
+            let mut curr = my_self.head.take();
+            while curr.is_some() {
+                let mut node = curr.unwrap();
+                return_vec.push(node.data);
+                if node.next.is_none() {
                     break;
                 }
-                curr = curr.next.take().unwrap();
+                curr = node.next.take();
             }
         } 
 
@@ -95,8 +89,7 @@ impl<T> Pushee<T> for Node<T> {
         &mut self.next
     }
 
-    fn peek(&self) -> Option<&T>
-    {
+    fn peek(&self) -> Option<&T> {
         Some(&self.data)
     }
 }
@@ -125,8 +118,7 @@ impl<T> Pushee<T> for SimpleLinkedList<T> {
         &mut self.head
     }
 
-    fn peek(&self) -> Option<&T>
-    {
+    fn peek(&self) -> Option<&T> {
         self.head.as_ref().map(|node| & node.data)
     }
 }
@@ -152,8 +144,7 @@ impl<T> Pushee<T> for Box<Node<T>> {
         unboxed.next_mut()
     }
 
-    fn peek(&self) -> Option<&T>
-    {
+    fn peek(&self) -> Option<&T> {
         let unboxed = &**self;
         unboxed.peek()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ trait Pushee<T> {
     fn push(&mut self, jawn: T);
     fn pop(&mut self) -> Option<T>;
     fn next(&mut self) -> &mut Link<T>;
+    fn peek(&self) -> Option<&T>;
 }
 
 impl<T> Pushee<T> for Node<T> {
@@ -89,6 +90,10 @@ impl<T> Pushee<T> for Node<T> {
         &mut self.next
     }
 
+    fn peek(&self) -> Option<&T>
+    {
+        Some(&self.data)
+    }
 }
 
 impl<T> Pushee<T> for SimpleLinkedList<T> {
@@ -110,6 +115,11 @@ impl<T> Pushee<T> for SimpleLinkedList<T> {
     fn next(&mut self) -> &mut Link<T> {
         &mut self.head
     }
+
+    fn peek(&self) -> Option<&T>
+    {
+        self.head.as_ref().map(|node| & node.data)
+    }
 }
 
 impl<T> Pushee<T> for Box<Node<T>> {
@@ -126,6 +136,12 @@ impl<T> Pushee<T> for Box<Node<T>> {
     fn next(&mut self) -> &mut Link<T> {
         let unboxed = &mut **self;
         unboxed.next()
+    }
+
+    fn peek(&self) -> Option<&T>
+    {
+        let unboxed = &**self;
+        unboxed.peek()
     }
 }
 
@@ -168,7 +184,7 @@ impl<'a, T> SimpleLinkedList<T> {
             if next.next.is_none() {
                 break;
             }
-            
+
             curr = curr.next().as_mut().unwrap();
         }
         curr.pop()

--- a/tests/simple-linked-list.rs
+++ b/tests/simple-linked-list.rs
@@ -15,79 +15,73 @@ fn test_push_increments_length() {
     assert_eq!(list.len(), 2, "list's length must be 2");
 }
 
-// #[test]
-// #[ignore]
-// fn test_pop_decrements_length() {
-//     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-//     list.push(1);
-//     list.push(2);
-//     list.pop();
-//     assert_eq!(list.len(), 1, "list's length must be 1");
-//     list.pop();
-//     assert_eq!(list.len(), 0, "list's length must be 0");
-// }
+#[test]
+fn test_pop_decrements_length() {
+    let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
+    list.push(1);
+    list.push(2);
+    list.pop();
+    assert_eq!(list.len(), 1, "list's length must be 1");
+    list.pop();
+    assert_eq!(list.len(), 0, "list's length must be 0");
+}
 
-// #[test]
-// #[ignore]
-// fn test_pop_returns_head_element_and_removes_it() {
-//     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-//     list.push(1);
-//     list.push(2);
-//     assert_eq!(list.pop(), Some(2), "Element must be 2");
-//     assert_eq!(list.pop(), Some(1), "Element must be 1");
-//     assert_eq!(list.pop(), None, "No element should be contained in list");
-// }
+#[test]
+fn test_pop_returns_head_element_and_removes_it() {
+    let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
+    list.push(1);
+    list.push(2);
+    assert_eq!(list.pop(), Some(2), "Element must be 2");
+    assert_eq!(list.pop(), Some(1), "Element must be 1");
+    assert_eq!(list.pop(), None, "No element should be contained in list");
+}
 
-// #[test]
-// #[ignore]
-// fn test_peek_returns_reference_to_head_element_but_does_not_remove_it() {
-//     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-//     assert_eq!(list.peek(), None, "No element should be contained in list");
-//     list.push(2);
-//     assert_eq!(list.peek(), Some(&2), "Element must be 2");
-//     assert_eq!(list.peek(), Some(&2), "Element must be still 2");
-//     list.push(3);
-//     assert_eq!(list.peek(), Some(&3), "Head element is now 3");
-//     assert_eq!(list.pop(), Some(3), "Element must be 3");
-//     assert_eq!(list.peek(), Some(&2), "Head element is now 2");
-//     assert_eq!(list.pop(), Some(2), "Element must be 2");
-//     assert_eq!(list.peek(), None, "No element should be contained in list");
-// }
+#[test]
+fn test_peek_returns_reference_to_head_element_but_does_not_remove_it() {
+    let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
+    assert_eq!(list.peek(), None, "No element should be contained in list");
+    list.push(2);
+    assert_eq!(list.peek(), Some(&2), "Element must be 2");
+    assert_eq!(list.peek(), Some(&2), "Element must be still 2");
+    list.push(3);
+    assert_eq!(list.peek(), Some(&3), "Head element is now 3");
+    assert_eq!(list.pop(), Some(3), "Element must be 3");
+    assert_eq!(list.peek(), Some(&2), "Head element is now 2");
+    assert_eq!(list.pop(), Some(2), "Element must be 2");
+    assert_eq!(list.peek(), None, "No element should be contained in list");
+}
 
-// #[test]
-// #[ignore]
-// fn test_from_slice() {
-//     let array = ["1", "2", "3", "4"];
-//     let mut list = SimpleLinkedList::from(array.as_ref());
-//     assert_eq!(list.pop(), Some("4"));
-//     assert_eq!(list.pop(), Some("3"));
-//     assert_eq!(list.pop(), Some("2"));
-//     assert_eq!(list.pop(), Some("1"));
-// }
+#[test]
+fn test_from_slice() {
+    let array = ["1", "2", "3", "4"];
+    let mut list = SimpleLinkedList::from(array.as_ref());
+    assert_eq!(list.pop(), Some("4"));
+    assert_eq!(list.pop(), Some("3"));
+    assert_eq!(list.pop(), Some("2"));
+    assert_eq!(list.pop(), Some("1"));
+}
 
-// #[test]
-// #[ignore]
-// fn test_reverse() {
-//     let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
-//     list.push(1);
-//     list.push(2);
-//     list.push(3);
-//     let mut rev_list = list.rev();
-//     assert_eq!(rev_list.pop(), Some(1));
-//     assert_eq!(rev_list.pop(), Some(2));
-//     assert_eq!(rev_list.pop(), Some(3));
-//     assert_eq!(rev_list.pop(), None);
-// }
+#[test]
+fn test_reverse() {
+    let mut list: SimpleLinkedList<u32> = SimpleLinkedList::new();
+    list.push(1);
+    list.push(2);
+    list.push(3);
+    let mut rev_list = list.rev();
+    assert_eq!(rev_list.pop(), Some(1));
+    assert_eq!(rev_list.pop(), Some(2));
+    assert_eq!(rev_list.pop(), Some(3));
+    assert_eq!(rev_list.pop(), None);
+}
 
-// #[test]
-// #[ignore]
-// fn test_into_vector() {
-//     let mut v = Vec::new();
-//     let mut s = SimpleLinkedList::new();
-//     for i in 1..4 {
-//         v.push(i);
-//         s.push(i);
-//     }
-//     let s_as_vec: Vec<i32> = s.into();
-//     assert_eq!(v, s_as_vec);
-// }
+#[test]
+fn test_into_vector() {
+    let mut v = Vec::new();
+    let mut s = SimpleLinkedList::new();
+    for i in 1..4 {
+        v.push(i);
+        s.push(i);
+    }
+    let s_as_vec: Vec<i32> = s.into();
+    assert_eq!(v, s_as_vec);
+}


### PR DESCRIPTION
Rather than pushing to the end, this changes the implementation to push to the head of the list, which makes the code a lot simpler and also keeps time complexity low.  

Added some stuff to reflect everything in the "An Ok List" chapter of [Learning Rust With Entirely Too Many Linked Lists](https://rust-unofficial.github.io/too-many-lists/second.html)